### PR TITLE
Fix index out of range

### DIFF
--- a/unique_string.go
+++ b/unique_string.go
@@ -53,8 +53,7 @@ func murmurHash64(data []byte) uint64 {
 	o := size - i
 
 	if o > 0 {
-		h1 := uint32(uint32(data[i]) | (uint32(data[i+1]) << 8) | (uint32(data[i+2]) << 16) | (uint32(data[i+3]) << 24))
-
+		var h1 uint32 = 0
 		if o < 4 {
 			switch o {
 			case 2:
@@ -64,6 +63,8 @@ func murmurHash64(data []byte) uint64 {
 			default:
 				h1 = uint32(data[i])
 			}
+		} else {
+			h1 = uint32(uint32(data[i]) | (uint32(data[i+1]) << 8) | (uint32(data[i+2]) << 16) | (uint32(data[i+3]) << 24))
 		}
 
 		h1 *= uint32(c4)

--- a/unique_string_test.go
+++ b/unique_string_test.go
@@ -27,6 +27,25 @@ func TestGenerateUniqueString(t *testing.T) {
 	}
 }
 
+func TestGenerateUniqueString_shortString(t *testing.T) {
+	prev := GenerateUniqueString("t")
+	if prev != "fsnwonksnm7cy" {
+		t.Fatalf("GenerateUniqueString(\"t\") should = fsnwonksnm7cy")
+	}
+	prev = GenerateUniqueString("te")
+	if prev != "o57ehhbytctgs" {
+		t.Fatalf("GenerateUniqueString(\"te\") should = o57ehhbytctgs")
+	}
+	prev = GenerateUniqueString("tes")
+	if prev != "ebse57jls4qbc" {
+		t.Fatalf("GenerateUniqueString(\"tes\") should = ebse57jls4qbc")
+	}
+	prev = GenerateUniqueString("t", "e")
+	if prev != "d5ykh7yoidm2a" {
+		t.Fatalf("GenerateUniqueString(\"t\", \"e\") should = d5ykh7yoidm2a")
+	}
+}
+
 func BenchmarkGenerateUniqueString(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		_ = GenerateUniqueString("test")


### PR DESCRIPTION
Fixed a bug where the index was out of range when the input string was short.

```go
func main() {
	if len(os.Args) == 1 {
		_, _ = fmt.Fprintf(os.Stderr, "usage: %s string1 [string2]...\n", os.Args[0])
		os.Exit(1)
	}

	fmt.Printf("%s\n", unique_string.GenerateUniqueString(os.Args[1:]...))
}
```

```bash
$ ./go-azure-unique-string a a
panic: runtime error: index out of range [3] with length 3

goroutine 1 [running]:
github.com/cloud-maker-ai/go-unique-string.murmurHash64({0x14000090020?, 0x102f29088?, 0x2?})
	/Users/yusuke.koyoshi/go/pkg/mod/github.com/cloud-maker-ai/go-unique-string@v0.0.0-20221215222937-c55128876647/unique_string.go:56 +0x304
github.com/cloud-maker-ai/go-unique-string.GenerateUniqueString({0x140000a0070?, 0x0?, 0x1400005e738?})
	/Users/yusuke.koyoshi/go/pkg/mod/github.com/cloud-maker-ai/go-unique-string@v0.0.0-20221215222937-c55128876647/unique_string.go:113 +0x44
main.main()
	/Users/yusuke.koyoshi/ghq/test/go-azure-unique-string/main.go:18 +0x54
```